### PR TITLE
Updates to use envvars and send socket data through the HTTP port

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -6,15 +6,6 @@ const Promise = require('bluebird');
  * @module db
  */
 
-// const db = mysql.createConnection({
-//   host: 'localhost',
-//   user: 'root',
-//   password: '',
-//   database: 'trivia',
-// });
-//
-// db.connect();
-
 const DB_HOST = process.env.OGS_HOST || 'localhost';
 const DB_USER = process.env.OGS_USER || 'root';
 const DB_PASS = process.env.OGS_PASS || '';
@@ -22,6 +13,7 @@ const DB_DATABASE = process.env.OGS_DATABASE || 'trivia';
 
 const databaseQueryString = `mysql://${DB_USER}:${DB_PASS}@${DB_HOST}/${DB_DATABASE}?reconnect=true`;
 
+// connection pooling is used here to recycle and prevent dropped connections
 const pool = mysql.createPool(databaseQueryString);
 
 const db = {};
@@ -52,13 +44,6 @@ db.getQuestions = (n = 5) => {
     LIMIT ${n}
     `;
   return new Promise((resolve, reject) => {
-    // db.query(queryString, (err, results) => {
-    //   if (err) {
-    //     reject(err);
-    //   } else {
-    //     resolve(results);
-    //   }
-    // });
     pool.getConnection((err, connection) => {
       if (err) {
         reject(err);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react-dev": "webpack -d --watch",
     "server-dev": "nodemon server/index.js",
     "test": "mocha --recursive test",
+    "start": "node server/index.js",
     "generate-jsdoc": "jsdoc -R README.md -c jsdoc_conf.json -d documentation"
   },
   "dependencies": {

--- a/server/index.js
+++ b/server/index.js
@@ -10,7 +10,7 @@ const SocketServerInterface = require('../socket/socketServerInterface.js');
 const io = new SocketServerInterface(server);
 
 const CLIENT_DIR = path.join(__dirname, '../client');
-const SERVER_PORT = 8080;
+const SERVER_PORT = process.env.PORT || 8080;
 // const SOCKET_PORT = 3000;
 
 server.listen(SERVER_PORT);

--- a/server/index.js
+++ b/server/index.js
@@ -11,12 +11,13 @@ const io = new SocketServerInterface(server);
 
 const CLIENT_DIR = path.join(__dirname, '../client');
 const SERVER_PORT = 8080;
-const SOCKET_PORT = 3000;
+// const SOCKET_PORT = 3000;
 
 server.listen(SERVER_PORT);
-io.listen(SOCKET_PORT);
+// io.listen(SOCKET_PORT);
+io.listen();
 console.log(`Server listening on port ${SERVER_PORT}`);
-console.log(`Socket listening on port ${SOCKET_PORT}`);
+// console.log(`Socket listening on port ${SOCKET_PORT}`);
 
 /* MIDDLEWARE */
 

--- a/server/index.js
+++ b/server/index.js
@@ -11,13 +11,11 @@ const io = new SocketServerInterface(server);
 
 const CLIENT_DIR = path.join(__dirname, '../client');
 const SERVER_PORT = process.env.PORT || 8080;
-// const SOCKET_PORT = 3000;
 
 server.listen(SERVER_PORT);
-// io.listen(SOCKET_PORT);
+// we don't specify a port so we will use the default port for the HTTP host
 io.listen();
 console.log(`Server listening on port ${SERVER_PORT}`);
-// console.log(`Socket listening on port ${SOCKET_PORT}`);
 
 /* MIDDLEWARE */
 

--- a/socket/socketClientInterface.js
+++ b/socket/socketClientInterface.js
@@ -1,6 +1,24 @@
+// import io from 'socket.io-client';
+//
+// const SOCKET_URL = 'http://localhost:3000';
+// const connection = io.connect(SOCKET_URL);
+//
+// export default connection;
+
 import io from 'socket.io-client';
 
-const SOCKET_URL = 'http://localhost:3000';
-const connection = io.connect(SOCKET_URL);
+const SOCKET_HOST = process.env.OGS_HOST || 'localhost';
+// const SOCKET_PORT = process.env.OGS_SOCKET_PORT || 3000;
+// const SOCKET_HOST = 'us-cdbr-iron-east-05.cleardb.net';
+const SOCKET_PORT = process.env.PORT || 3000;
+
+const SOCKET_URL = `${SOCKET_HOST}:${SOCKET_PORT}`;
+
+console.log('*** SOCKET_URL:', SOCKET_URL);
+
+// const connection = io.connect(SOCKET_URL);
+
+// we will use the default connection params of the host
+const connection = io();
 
 export default connection;

--- a/socket/socketClientInterface.js
+++ b/socket/socketClientInterface.js
@@ -1,24 +1,11 @@
-// import io from 'socket.io-client';
-//
-// const SOCKET_URL = 'http://localhost:3000';
-// const connection = io.connect(SOCKET_URL);
-//
-// export default connection;
-
 import io from 'socket.io-client';
 
-const SOCKET_HOST = process.env.OGS_HOST || 'localhost';
-// const SOCKET_PORT = process.env.OGS_SOCKET_PORT || 3000;
-// const SOCKET_HOST = 'us-cdbr-iron-east-05.cleardb.net';
-const SOCKET_PORT = process.env.PORT || 3000;
+// const SOCKET_HOST = process.env.OGS_HOST || 'localhost';
+// const SOCKET_PORT = process.env.PORT || 3000;
+//
+// const SOCKET_URL = `${SOCKET_HOST}:${SOCKET_PORT}`;
 
-const SOCKET_URL = `${SOCKET_HOST}:${SOCKET_PORT}`;
-
-console.log('*** SOCKET_URL:', SOCKET_URL);
-
-// const connection = io.connect(SOCKET_URL);
-
-// we will use the default connection params of the host
+// we will use the default connection params of the host connection
 const connection = io();
 
 export default connection;

--- a/socket/socketClientInterface.js
+++ b/socket/socketClientInterface.js
@@ -1,11 +1,7 @@
 import io from 'socket.io-client';
 
-// const SOCKET_HOST = process.env.OGS_HOST || 'localhost';
-// const SOCKET_PORT = process.env.PORT || 3000;
-//
-// const SOCKET_URL = `${SOCKET_HOST}:${SOCKET_PORT}`;
-
 // we will use the default connection params of the host connection
+// if we want to have the ability to specify the port, we can add it to the interface as well
 const connection = io();
 
 export default connection;

--- a/socket/socketServerInterface.js
+++ b/socket/socketServerInterface.js
@@ -20,8 +20,10 @@ class SocketServerInterface {
     this.scheduledEmission = null;
   }
 
-  listen(port) {
-    this.io.listen(port);
+  listen(port = undefined) {
+    if (port) {
+      this.io.listen(port);
+    }
     this.listenForPregameEvents();
   }
 

--- a/socket/socketServerInterface.js
+++ b/socket/socketServerInterface.js
@@ -20,6 +20,7 @@ class SocketServerInterface {
     this.scheduledEmission = null;
   }
 
+  // port can be undefined here, if we want to route all comm through the HTTP server port
   listen(port = undefined) {
     if (port) {
       this.io.listen(port);


### PR DESCRIPTION
Heroku only allows a single port exposed, so this was necessary. Using the code locally still works fine, so no problem there.

If we want the option to specify port, we'll have to add that to the socketClientInterface.js file.

This was the minimal changes necessary on the code side to get some semblance of socket communication working on Heroku.

I'm still ironing out the dropped communication issues...

Please try out the branch first before merging and let me know if there are issues.

Thanks!